### PR TITLE
Add function isoweekday() to return an integer consistent with ISO 8601:

### DIFF
--- a/src/lib/mod_datetime.f90
+++ b/src/lib/mod_datetime.f90
@@ -74,6 +74,7 @@ type :: datetime
   procedure,pass(self),public :: tzOffset
   procedure,pass(self),public :: utc
   procedure,pass(self),public :: weekday
+  procedure,pass(self),public :: isoweekday
   procedure,pass(self),public :: weekdayLong
   procedure,pass(self),public :: weekdayShort
   procedure,pass(self),public :: yearday
@@ -548,7 +549,28 @@ pure elemental integer function weekday(self)
 
 endfunction weekday
 
+pure elemental integer function isoweekday(self)
 
+  !! Returns the day of the week per ISO 8601 returned from weekday().
+  !! Returned value is an integer scalar in the range [1-7], such that:
+  !!
+  !! 1: Monday
+  !! 2: Tuesday
+  !! 3: Wednesday
+  !! 4: Thursday
+  !! 5: Friday
+  !! 6: Saturday
+  !! 7: Sunday
+
+  class(datetime),intent(in) :: self !! `datetime` instance
+
+  isoweekday = self % weekday()
+  
+  if (isoweekday == 0) then
+    isoweekday = 7
+  end if
+
+endfunction isoweekday
 
 pure elemental character(len=9) function weekdayLong(self)
 

--- a/src/tests/datetime_tests.f90
+++ b/src/tests/datetime_tests.f90
@@ -717,6 +717,41 @@ SUBROUTINE test_datetime
   WRITE(UNIT=STDOUT,FMT='(71("-"))')
 
   !---------------------------------------------------------------------
+  ! datetime % isoweekday()
+
+  a = datetime(2014,1,1)
+  tests(n) = assert(a % isoweekday() == 3,'datetime % isoweekday(), Wednesday')
+  n = n+1
+
+  a = datetime(2014,1,2)
+  tests(n) = assert(a % isoweekday() == 4,'datetime % isoweekday(), Thursday')
+  n = n+1
+
+  a = datetime(2014,1,3)
+  tests(n) = assert(a % isoweekday() == 5,'datetime % isoweekday(), Friday')
+  n = n+1
+
+  a = datetime(2014,1,4)
+  tests(n) = assert(a % isoweekday() == 6,'datetime % isoweekday(), Saturday')
+  n = n+1
+
+  a = datetime(2014,1,5)
+  tests(n) = assert(a % isoweekday() == 7,'datetime % isoweekday(), Sunday')
+  n = n+1
+
+  a = datetime(2014,1,6)
+  tests(n) = assert(a % isoweekday() == 1,'datetime % isoweekday(), Monday')
+  n = n+1
+
+  a = datetime(2014,1,7)
+  tests(n) = assert(a % isoweekday() == 2,'datetime % isoweekday(), Tuesday')
+  n = n+1
+
+  !---------------------------------------------------------------------
+
+  WRITE(UNIT=STDOUT,FMT='(71("-"))')
+
+  !---------------------------------------------------------------------
   ! datetime % weekdayLong()
 
   a = datetime(2014,1,1)


### PR DESCRIPTION
integer range [1-7] where Monday=1..Sunday=7.  isoweekday() uses weekday()
to perform the calculations.

Add tests to check correct isoweekday() return values.