### PR TITLE
Cmake: modernize and correct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
-language: generic
+language: minimal
+
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
       - gfortran-6
+
 before_script:
   - FC=gfortran-6 cmake .
-  - make
+  - cmake --build . --parallel
 script:
   - ctest
-notifications:
-  email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,24 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "default to Release")
 endif()
 project(datetime-fortran
 LANGUAGES Fortran
 VERSION 1.6.1)
-
-# set output paths for modules, archives, and executables
-set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+enable_testing()
 
 # library to archive (libdatetime.a)
-add_library(datetime src/lib/datetime.f90 src/lib/mod_datetime.f90 src/lib/mod_timedelta.f90 src/lib/mod_clock.f90 src/lib/mod_strftime.f90 src/lib/mod_constants.f90)
+add_library(datetime src/lib/datetime.f90 src/lib/mod_datetime.f90 src/lib/mod_timedelta.f90
+src/lib/mod_clock.f90 src/lib/mod_strftime.f90 src/lib/mod_constants.f90)
+target_include_directories(datetime INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/include)
+set_target_properties(datetime PROPERTIES
+Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include
+ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 # tests
-enable_testing()
 add_executable(datetime_tests src/tests/datetime_tests.f90)
 target_link_libraries(datetime_tests datetime)
-add_test(datetime_tests bin/datetime_tests)
+set_target_properties(datetime_tests PROPERTIES
+RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+add_test(NAME datetime_tests COMMAND $<TARGET_FILE:datetime_tests>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,16 @@
-# cmake version, project name, language
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
-project(datetime-fortran Fortran)
+cmake_minimum_required(VERSION 2.8)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "default to Release")
+endif()
+project(datetime-fortran
+LANGUAGES Fortran
+VERSION 1.6.1)
 
 # set output paths for modules, archives, and executables
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-
-# if build type not specified, default to release
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "release")
-endif()
-
-# compiler flags for gfortran
-if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -C -fbacktrace")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-endif()
-
-# compiler flags for ifort
-if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume realloc_lhs -heap-arrays")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -C -traceback")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-endif()
 
 # library to archive (libdatetime.a)
 add_library(datetime src/lib/datetime.f90 src/lib/mod_datetime.f90 src/lib/mod_timedelta.f90 src/lib/mod_clock.f90 src/lib/mod_strftime.f90 src/lib/mod_constants.f90)


### PR DESCRIPTION
This PR is to modernize and correct CMake for use in projects via ExternalProject or FetchContent.

* CMAKE_BUILD_TYPE must be set before project() to take effect.
* the compiler options are already default and can conflict with CMake internal defaults, there isn't any need for them
* use target properties rather than globals
