### PR TITLE
Increase range for secondsSinceEpoch()

### DIFF
--- a/src/datetime_module.f90
+++ b/src/datetime_module.f90
@@ -656,7 +656,7 @@ contains
     class(datetime), intent(in) :: self
     character(*), intent(in)  :: format
     character(:), allocatable :: strftime
-    integer :: n, rc
+    integer :: rc
     character(MAXSTRLEN) :: resultString
     resultString = ""
     rc = c_strftime(resultString, len(resultString), trim(format) // c_null_char, &

--- a/src/datetime_module.f90
+++ b/src/datetime_module.f90
@@ -1,6 +1,7 @@
 module datetime_module
 
-  use, intrinsic :: iso_fortran_env, only: real32, real64, stderr => error_unit
+  use, intrinsic :: iso_fortran_env, only: int64, real32, real64, &
+                                           stderr => error_unit
   use, intrinsic :: iso_c_binding, only: c_char, c_int, c_null_char
 
   implicit none
@@ -633,18 +634,18 @@ contains
   end function isocalendar
 
 
-  integer function secondsSinceEpoch(self)
-    ! Returns an integer number of seconds since the UNIX Epoch,
-    ! `1970-01-01 00:00:00`.
-    ! Since Windows does not have strftime('%s'), we implement this
-    ! using datetime itself
+  integer(int64) function secondsSinceEpoch(self)
+    ! Returns an integer number of seconds since the UNIX Epoch (1 Jan 1970).
+    ! Since Windows does not have strftime('%s'), we implement this using
+    ! datetime itself.
     class(datetime), intent(in) :: self
     type(timedelta) :: td
-    type(datetime) :: dummy
+    type(datetime) :: this_time, unix_time
 
-    dummy = datetime(self%year, self%month, self%day, self%hour, self%minute, self%second)
-
-    td = datetime_minus_datetime(dummy, datetime(1970,1,1,0,0,0))
+    this_time = datetime(self%year, self%month, self%day, &
+                         self%hour, self%minute, self%second)
+    unix_time = datetime(1970, 1, 1, 0, 0, 0)
+    td = datetime_minus_datetime(this_time, unix_time)
     secondsSinceEpoch = td%total_seconds()
 
   end function secondsSinceEpoch

--- a/src/datetime_module.f90
+++ b/src/datetime_module.f90
@@ -639,14 +639,14 @@ contains
     ! Since Windows does not have strftime('%s'), we implement this using
     ! datetime itself.
     class(datetime), intent(in) :: self
-    type(timedelta) :: td
+    type(timedelta) :: delta
     type(datetime) :: this_time, unix_time
 
     this_time = datetime(self%year, self%month, self%day, &
                          self%hour, self%minute, self%second)
     unix_time = datetime(1970, 1, 1, 0, 0, 0)
-    td = datetime_minus_datetime(this_time, unix_time)
-    secondsSinceEpoch = td%total_seconds()
+    delta = this_time - unix_time
+    secondsSinceEpoch = delta%total_seconds()
 
   end function secondsSinceEpoch
 

--- a/tests/datetime_tests.f90
+++ b/tests/datetime_tests.f90
@@ -78,7 +78,7 @@ contains
     real(real64) :: eps = tiny(1._real64)
     logical, allocatable :: tests(:)
     logical :: test_failed
-    integer :: i, n, ntests, tzOffset
+    integer :: i, n, ntests
 
     print *
 

--- a/tests/datetime_tests.f90
+++ b/tests/datetime_tests.f90
@@ -1,6 +1,6 @@
 module datetime_tests
   use datetime_module
-  use, intrinsic :: iso_fortran_env, only: real64
+  use, intrinsic :: iso_fortran_env, only: int64, real64
 
   implicit none
 
@@ -83,7 +83,7 @@ contains
     print *
 
     ! Test counter; modify if adding new tests
-    ntests = 191
+    ntests = 192
 
     call initialize_tests(tests, ntests)
 
@@ -549,6 +549,11 @@ contains
     a = datetime(1969, 12, 31, 23, 0, 0)
     tests(n) = assert(a % secondsSinceEpoch() == -3600, &
                       'datetime % secondsSinceEpoch(),  -1 hour')
+    n = n + 1
+
+    a = datetime(2070, 1, 1)
+    tests(n) = assert(a % secondsSinceEpoch() == 3155760000_int64, &
+                      'datetime % secondsSinceEpoch(), 100 years')
     n = n + 1
 
     print '(71("-"))'


### PR DESCRIPTION
Originally, `datetime % secondsSinceEpoch()` returns an `integer`, which on most or all compilers defaults to `int32`. This limits the result to be valid only for a difference of up to about 68 years. This range can be expanded by promoting the result of `datetime % secondsSinceEpoch()` to `int64`. This PR does that.

Though this could be considered a bug fix (because for deltas of > 68 years the result would overflow), it's not a backward compatible change. User code could be passing the result of this function directly as an actual argument for which the dummy is declared as `int32`, which would break user code (I don't know that such user code exists). According to semver, this then warrants a major version bump to 2.0.0. Did I get this correct or is this still a patch-version change?
