### PR TITLE
Force ar/ranlib to do a deterministic build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ LANGUAGES Fortran
 VERSION 1.7.0)
 include(CTest)
 
-SET(CMAKE_Fortran_ARCHIVE_CREATE "<CMAKE_AR> qcD <TARGET> <LINK_FLAGS> <OBJECTS>")
-SET(CMAKE_Fortran_ARCHIVE_FINISH "<CMAKE_RANLIB> -D <TARGET>")
+set(CMAKE_Fortran_ARCHIVE_CREATE "<CMAKE_AR> qcD <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_Fortran_ARCHIVE_FINISH "<CMAKE_RANLIB> -D <TARGET>")
 
 # library to archive (libdatetime.a)
 add_library(datetime src/datetime_module.f90)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ LANGUAGES Fortran
 VERSION 1.7.0)
 include(CTest)
 
+SET(CMAKE_Fortran_ARCHIVE_CREATE "<CMAKE_AR> qcD <TARGET> <LINK_FLAGS> <OBJECTS>")
+SET(CMAKE_Fortran_ARCHIVE_FINISH "<CMAKE_RANLIB> -D <TARGET>")
+
 # library to archive (libdatetime.a)
 add_library(datetime src/datetime_module.f90)
 target_include_directories(datetime INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/include)


### PR DESCRIPTION
I noticed that datetime-fortran does not create deterministic builds. Details are documented in: https://github.com/ACCESS-NRI/ACCESS-OM/issues/8