### PR TITLE
New functions monthLong and monthShort to get the name of the month

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ See some basic examples [here](examples).
         * [*isocalendar*](#isocalendar)
         * [*isoformat*](#isoformat)
         * [*isValid*](#isvalid)
+        * [*monthLong*](#monthlong)
+        * [*monthShort*](#monthshort)
         * [*now*](#now)
         * [*secondsSinceEpoch*](#secondssinceepoch)
         * [*strftime*](#strftime)
@@ -196,6 +198,8 @@ type :: datetime
   procedure,pass(self),public :: weekdayShort
   procedure,pass(self),public :: isoweekdayShort
   procedure,pass(self),public :: yearday
+  procedure,pass(self),public :: monthLong
+  procedure,pass(self),public :: monthShort
 
   ! private methods
   procedure,pass(self),private :: addMilliseconds
@@ -465,6 +469,68 @@ print *, a % isValid() ! .false.
 ```
 
 #### See also
+
+[Back to top](#top)
+<hr>
+
+### monthLong<a id="monthlong"></a>
+
+```fortran
+pure elemental character(len=9) function monthLong(self)
+  class(datetime),intent(in) :: self
+```
+
+Returns the full name of the month.
+
+#### Example usage
+
+```fortran
+use datetime_module,only:datetime
+
+type(datetime)  :: a
+
+! Initialize:
+a = datetime(2013,1,1)
+
+print *, a % monthLong() ! January
+```
+
+#### See also
+
+* [*getMonth*](#getmonth)
+
+* [*monthShort*](#monthshort)
+
+[Back to top](#top)
+<hr>
+
+### monthShort<a id="monthshort"></a>
+
+```fortran
+pure elemental character(len=3) function monthShort(self)
+  class(datetime),intent(in) :: self
+```
+
+Returns the short (3-letter) name of the month.
+
+#### Example usage
+
+```fortran
+use datetime_module,only:datetime
+
+type(datetime)  :: a
+
+! Initialize:
+a = datetime(2013,1,1)
+
+print *, a % monthShort() ! Jan
+```
+
+#### See also
+
+* [*getMonth*](#getmonth)
+
+* [*monthLong*](#monthLong)
 
 [Back to top](#top)
 <hr>

--- a/README.md
+++ b/README.md
@@ -297,6 +297,12 @@ pure elemental integer function getMonth(self)
 ```
 Returns the month of a `datetime` instance.
 
+#### See also
+
+* [*monthLong*](#monthLong)
+
+* [*monthShort*](#monthShort)
+
 [Back to top](#top)
 <hr>
 

--- a/src/datetime_module.f90
+++ b/src/datetime_module.f90
@@ -80,6 +80,8 @@ module datetime_module
     procedure, pass(self), public :: weekdayLong
     procedure, pass(self), public :: weekdayShort
     procedure, pass(self), public :: yearday
+    procedure, pass(self), public :: monthLong
+    procedure, pass(self), public :: monthShort
 
     ! private methods
     procedure, pass(self), private :: addMilliseconds
@@ -613,6 +615,25 @@ contains
     isoweekdayShort = days(self % isoweekday())
   end function isoweekdayShort
 
+  pure elemental character(9) function monthLong(self)
+    ! Returns the full name of the month.
+    class(datetime), intent(in) :: self
+    character(9), parameter :: &
+      months(*) = ['January  ', 'February ', 'March    ', 'April    ', &
+                   'May      ', 'June     ', 'July     ', 'August   ', &
+                   'September', 'October  ', 'November ', 'December ']
+    monthLong = months(self%getMonth())
+  end function monthLong
+
+  pure elemental character(3) function monthShort(self)
+    ! Returns the short (3-letter) name of the month.
+    class(datetime), intent(in) :: self
+    character(3), parameter :: &
+      months(*) = ['Jan', 'Feb', 'Mar', 'Apr', &
+                   'May', 'Jun', 'Jul', 'Aug', &
+                   'Sep', 'Oct', 'Nov', 'Dec']
+    monthShort = months(self%getMonth())
+  end function monthShort
 
   function isocalendar(self)
     ! Returns an array of 3 integers, year, week number, and week day,

--- a/tests/datetime_tests.f90
+++ b/tests/datetime_tests.f90
@@ -83,7 +83,7 @@ contains
     print *
 
     ! Test counter; modify if adding new tests
-    ntests = 192
+    ntests = 216
 
     call initialize_tests(tests, ntests)
 
@@ -877,6 +877,110 @@ contains
     a = datetime(2014, 12, 1)
     tests(n) = assert(a % yearday() == 335, &
                       'datetime(2014, 12, 1) % yearday() == 335')
+    n = n + 1
+
+    print '(71("-"))'
+
+    ! datetime % monthLong()
+
+    a = datetime(2014, 1, 1)
+    tests(n) = assert(a % monthLong() == 'January', 'datetime % monthLong(),  January')
+    n = n + 1
+
+    a = datetime(2014, 2, 1)
+    tests(n) = assert(a % monthLong() == 'February', 'datetime % monthLong(),  February')
+    n = n + 1
+
+    a = datetime(2014, 3, 1)
+    tests(n) = assert(a % monthLong() == 'March', 'datetime % monthLong(),  March')
+    n = n + 1
+
+    a = datetime(2014, 4, 1)
+    tests(n) = assert(a % monthLong() == 'April', 'datetime % monthLong(),  April')
+    n = n + 1
+
+    a = datetime(2014, 5, 1)
+    tests(n) = assert(a % monthLong() == 'May', 'datetime % monthLong(),  May')
+    n = n + 1
+
+    a = datetime(2014, 6, 1)
+    tests(n) = assert(a % monthLong() == 'June', 'datetime % monthLong(),  June')
+    n = n + 1
+
+    a = datetime(2014, 7, 1)
+    tests(n) = assert(a % monthLong() == 'July', 'datetime % monthLong(),  July')
+    n = n + 1
+
+    a = datetime(2014, 8, 1)
+    tests(n) = assert(a % monthLong() == 'August', 'datetime % monthLong(),  August')
+    n = n + 1
+
+    a = datetime(2014, 9, 1)
+    tests(n) = assert(a % monthLong() == 'September', 'datetime % monthLong(),  September')
+    n = n + 1
+
+    a = datetime(2014,10, 1)
+    tests(n) = assert(a % monthLong() == 'October', 'datetime % monthLong(),  October')
+    n = n + 1
+
+    a = datetime(2014,11, 1)
+    tests(n) = assert(a % monthLong() == 'November', 'datetime % monthLong(),  November')
+    n = n + 1
+
+    a = datetime(2014,12, 1)
+    tests(n) = assert(a % monthLong() == 'December', 'datetime % monthLong(),  December')
+    n = n + 1
+
+    print '(71("-"))'
+
+    ! datetime % monthShort()
+
+    a = datetime(2014, 1, 1)
+    tests(n) = assert(a % monthShort() == 'Jan', 'datetime % monthShort(),  January')
+    n = n + 1
+
+    a = datetime(2014, 2, 1)
+    tests(n) = assert(a % monthShort() == 'Feb', 'datetime % monthShort(),  February')
+    n = n + 1
+
+    a = datetime(2014, 3, 1)
+    tests(n) = assert(a % monthShort() == 'Mar', 'datetime % monthShort(),  March')
+    n = n + 1
+
+    a = datetime(2014, 4, 1)
+    tests(n) = assert(a % monthShort() == 'Apr', 'datetime % monthShort(),  April')
+    n = n + 1
+
+    a = datetime(2014, 5, 1)
+    tests(n) = assert(a % monthShort() == 'May', 'datetime % monthShort(),  May')
+    n = n + 1
+
+    a = datetime(2014, 6, 1)
+    tests(n) = assert(a % monthShort() == 'Jun', 'datetime % monthShort(),  June')
+    n = n + 1
+
+    a = datetime(2014, 7, 1)
+    tests(n) = assert(a % monthShort() == 'Jul', 'datetime % monthShort(),  July')
+    n = n + 1
+
+    a = datetime(2014, 8, 1)
+    tests(n) = assert(a % monthShort() == 'Aug', 'datetime % monthShort(),  August')
+    n = n + 1
+
+    a = datetime(2014, 9, 1)
+    tests(n) = assert(a % monthShort() == 'Sep', 'datetime % monthShort(),  September')
+    n = n + 1
+
+    a = datetime(2014,10, 1)
+    tests(n) = assert(a % monthShort() == 'Oct', 'datetime % monthShort(),  October')
+    n = n + 1
+
+    a = datetime(2014,11, 1)
+    tests(n) = assert(a % monthShort() == 'Nov', 'datetime % monthShort(),  November')
+    n = n + 1
+
+    a = datetime(2014,12, 1)
+    tests(n) = assert(a % monthShort() == 'Dec', 'datetime % monthShort(),  December')
     n = n + 1
 
     print '(71("-"))'


### PR DESCRIPTION
* monthLong returns the full name of the month.
* monthShort returns the short (3 letter) name of the month.
* Documentation in the README file has been added for these functions.
* Tests have been updated.